### PR TITLE
Page speed reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ node_modules/
 gemini/
 gemini-report/
 reports/
+tmp/
+npm-debug.log

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,62 @@
+// Use only if your Grunt plugin isn't available for Gulp
+// All grunt tasks run as gulp tasks
+// For more information read https://www.npmjs.com/package/gulp-grunt
+// As main JavaScript task runner use Gulp
+
+module.exports = function(grunt) {
+  grunt.initConfig({
+    wpt: {
+      options: {
+        locations: ['Dulles:Chrome'],
+        key: 'A.9680d066b8ba2f4876d57c54f7b36a19'
+      },
+      sideroad: {
+        options: {
+          url: [
+            'http://www.jetthoughts.com/',
+            'http://www.jetthoughts.com/portfolio.html',
+            'http://www.jetthoughts.com/team.html',
+            'http://www.jetthoughts.com/career.html',
+            'http://www.jetthoughts.com/work.html',
+            'http://www.jetthoughts.com/blog/index.html',
+            'http://www.jetthoughts.com/contact.html'
+          ]
+        },
+        dest: 'tmp/sideroad/'
+      }
+    },
+    pagespeed: {
+      options: {
+        nokey: true,
+        url: "http://www.jetthoughts.com"
+      },
+      prod: {
+        options: {
+          url: "http://www.jetthoughts.com",
+          locale: "en_GB",
+          strategy: "desktop",
+          threshold: 80
+        }
+      },
+      paths: {
+        options: {
+          paths: [
+                    "/portfolio.html",
+                    "/team.html",
+                    "/career.html",
+                    "/work.html",
+                    "/blog/index.html",
+                    "/contact.html"
+                 ],
+          locale: "en_GB",
+          strategy: "desktop",
+          threshold: 80
+        }
+      }
+    }
+  });
+
+  grunt.loadNpmTasks('grunt-wpt');
+
+  grunt.loadNpmTasks('grunt-pagespeed');
+}

--- a/README.md
+++ b/README.md
@@ -80,6 +80,25 @@ You can run tests only in console without creating report, to do that run comman
 gemini test tests/gemini_tests/all_pages.js
 ```
 
+##Benchmarking
+
+For automating checking PageSpeed score as a part of CI we are using `grunt-pagespeed`
+
+```
+gulp pagespeed
+```
+
+And for WebPageTest scores we use `grunt-wpt`
+
+```
+gulp wpt_pagespeed
+```
+
+Also we use online pagespeed testing:
+
+```
+http://www.webpagetest.org/video
+```
 
 #Content workflow
 

--- a/_config.yml
+++ b/_config.yml
@@ -31,7 +31,8 @@ exclude:
     gemini-report,
     reports,
     tests,
-    bower_components/jquery-placeholder/demo.html
+    bower_components/jquery-placeholder/demo.html,
+    Gruntfile.js
   ]
 excerpt_separator: <!--cut-->
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -45,7 +45,6 @@ gulp.task('imagemin', function () {
     .pipe(gulp.dest('images'));
 });
 
-
 gulp.task('compass', function () {
   gulp.src(assets.styles)
     .pipe(sourcemaps.init())
@@ -57,7 +56,6 @@ gulp.task('compass', function () {
     .pipe(sourcemaps.write('./'))
     .pipe(gulp.dest('./css'));
 });
-
 
 gulp.task('uglify', function () {
   gulp.src(assets.js)
@@ -77,3 +75,17 @@ gulp.task('jekyll', shell.task('jekyll serve -w'));
 gulp.task('default', ['watch', 'jekyll', 'uglify', 'compass']);
 
 gulp.task('minify', ['imagemin', 'uglify', 'compass', 'uncss']);
+
+// grunt tatsks for gulp
+require('gulp-grunt')(gulp, {
+  base: null,
+  prefix: 'grunt-',
+});
+
+gulp.task('wpt_pagespeed', function() {
+  gulp.run('grunt-wpt');
+})
+
+gulp.task('pagespeed', function() {
+  gulp.run('grunt-pagespeed');
+})

--- a/package.json
+++ b/package.json
@@ -19,16 +19,19 @@
   "homepage": "http://jetthoughts.com",
   "devDependencies": {
     "gulp": "~3.8.9",
-    "gulp-imagemin": "~1.2.1",
-    "imagemin-pngcrush": "~4.0.0",
-    "gulp-sourcemaps": "~1.2.4",
     "gulp-compass": "~2.0.1",
     "gulp-concat": "~2.4.1",
-    "gulp-uglifyjs": "~0.4.4",
-    "gulp-shell": "~0.2.10",
-    "gulp-uncss": "~0.5.1",
-    "glob": "~4.0.6",
     "gulp-cssmin": "~0.1.6",
-    "require-dir": "~0.1.0"
+    "gulp-imagemin": "~1.2.1",
+    "gulp-shell": "~0.2.10",
+    "gulp-sourcemaps": "~1.2.4",
+    "gulp-uglifyjs": "~0.4.4",
+    "gulp-uncss": "~0.5.1",
+    "imagemin-pngcrush": "~4.0.0",
+    "require-dir": "~0.1.0",
+    "glob": "~4.0.6",
+    "grunt": "^0.4.5",
+    "grunt-pagespeed": "^0.4.1",
+    "grunt-wpt": "^3.1.1"
   }
 }


### PR DESCRIPTION
- [x] use [gulp-grunt](https://www.npmjs.com/package/gulp-grunt) for running grunt plugins on gulp.
- [x] use [grunt-wpt](https://www.npmjs.com/package/grunt-wpt) for WebPageTest scores
-  use [grunt-pagespeed](https://www.npmjs.com/package/grunt-pagespeed) for automating checking PageSpeed score as a part of CI. (deprecated)
- [x] update README
- [x] update WIKI
- [x] generate reports
