### PR TITLE
Updated robots.txt

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -7,5 +7,5 @@ Disallow: /assets/styles*
 Disallow: /assets/application*
 Disallow: /assets/Graphik*
 Disallow: /index.*
-Sitemap: https://jetthoughts.com/sitemap.xml
-Host: https://jetthoughts.com
+Sitemap: https://www.jetthoughts.com/sitemap.xml
+Host: https://www.jetthoughts.com

--- a/robots.txt
+++ b/robots.txt
@@ -6,5 +6,6 @@ Disallow: /assets/vendor
 Disallow: /assets/styles*
 Disallow: /assets/application*
 Disallow: /assets/Graphik*
+Disallow: /index.*
 Sitemap: https://jetthoughts.com/sitemap.xml
 Host: https://jetthoughts.com


### PR DESCRIPTION
Disallow index pages and fixed site name.

It would fix issue:

```
Search engines see your https://www.jetthoughts.com and https://www.jetthoughts.com/index.html (or https://www.jetthoughts.com/index.php) as different pages.
With a variety of URLs, it's more challenging to get consolidated metrics for a specific piece of content.
```

Also https://jetthoughts.com/ is not reachable fixed robots to use https://www.jetthoughts.com