### PR TITLE
Fix height quote frame

### DIFF
--- a/_assets/css/layout/_ai-testimonials.scss
+++ b/_assets/css/layout/_ai-testimonials.scss
@@ -2,6 +2,9 @@
   padding: 183px 0 197px;
   color: #a6a6a6;
   background: #f7f7f7;
+  .slick-track{
+    display: flex;
+  }
   .list {
     list-style: none;
     padding: 0;
@@ -15,11 +18,13 @@
     width: 50%;
     padding: 0 10px 20px;
     outline: none;
+    height: auto;
   }
 }
 .ai-testimonial {
   background: #fff;
   padding: 37px 35px 30px;
+  height: 100%;
 }
 .ai-testimonial__foto {
   float: left;


### PR DESCRIPTION
Looks good to me, the only thing is that the frame bottom borders are different for Elliot Koolik and Tylers quotes,
image
![image](https://user-images.githubusercontent.com/23320186/54187135-8e60f900-44b5-11e9-8e6d-b79f104ab59d.png)

the other thing is that even though we have separated the text now those rows are hard to read because text goes to a new line with no logic in it.