### PR TITLE
Fix SEO error about duplicated content and multiple sitemaps

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -9,7 +9,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
   <meta name="title" content="{{ site.title }}">
   <meta name="description" content="{{ site.description }}"/>
-  <link rel="canonical" href="{{ site.url }}" />
+  <link rel="canonical" href="{{ site.url }}{{ page.url | replace:'index.html',''}}">
   <meta name="keywords" content="{{ site.keywords }}">
 
   <meta property="og:url" content="{{ site.url }}">


### PR DESCRIPTION
![](https://cl.ly/f95c1fe5dbe9/Image%202019-04-02%20at%2022.58.22.png)

![](https://cl.ly/712ec97dc480/Image%202019-04-04%20at%2017.13.41.png)

Guides:

* https://support.google.com/webmasters/answer/139066?hl=en
* https://sitechecker.pro/duplicate-content/