### PR TITLE
Upgrade packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   deploy:
     docker:
-      - image: circleci/ruby:2.4.3-node-browsers
+      - image: circleci/ruby:2.6.5-node-browsers
     steps:
       - checkout
       - run:

--- a/Gemfile
+++ b/Gemfile
@@ -1,13 +1,15 @@
 source 'https://rubygems.org'
 
-gem 'jekyll', '>= 3'
+gem 'jekyll', '>= 4'
 
 gem 'minima', '~> 2.0'
 gem 'autoprefixer-rails'
 
 group :jekyll_plugins do
    gem 'jekyll-feed'
-   gem 'jekyll-assets'
+   gem 'jekyll-assets', :git => 'https://github.com/kou/jekyll-assets.git', :branch => 'add-support-for-sprockets-4.0'
+   gem 'jekyll-sanity', :git => 'https://github.com/envygeeks/jekyll-sanity.git'
+   gem 'sass'
    gem 'jekyll-minifier'
    gem 'jekyll-redirect-from'
    gem 'jekyll-sitemap'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,28 @@
+GIT
+  remote: https://github.com/envygeeks/jekyll-sanity.git
+  revision: 7096a6c3b236ffa3ad2a6a4233b0ff47a47d37aa
+  specs:
+    jekyll-sanity (1.2.1)
+      jekyll (>= 3.1, < 5.0)
+
+GIT
+  remote: https://github.com/kou/jekyll-assets.git
+  revision: 591fcfc69672ad877a20e9f757650ebfa80276d4
+  branch: add-support-for-sprockets-4.0
+  specs:
+    jekyll-assets (4.0.0.alpha)
+      activesupport (~> 5.0)
+      execjs (~> 2.7)
+      extras (~> 0.2)
+      fastimage (~> 2.0, >= 1.8)
+      jekyll (>= 3.5, < 5.0)
+      jekyll-sanity (~> 1.2)
+      liquid-tag-parser (~> 1.0)
+      nokogiri (~> 1.10)
+      pathutil (~> 0.16)
+      sassc (>= 1.11, < 3.0)
+      sprockets (~> 4.0.beta7)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -6,9 +31,9 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    addressable (2.6.0)
-      public_suffix (>= 2.0.2, < 4.0)
-    autoprefixer-rails (9.5.1)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
+    autoprefixer-rails (9.6.5)
       execjs
     colorator (1.1.0)
     concurrent-ruby (1.1.5)
@@ -20,37 +45,28 @@ GEM
     execjs (2.7.0)
     extras (0.3.0)
       forwardable-extended (~> 2.5)
-    fastimage (2.1.5)
-    ffi (1.10.0)
+    fastimage (2.1.7)
+    ffi (1.11.1)
     forwardable-extended (2.6.0)
     htmlcompressor (0.4.0)
     http_parser.rb (0.6.0)
-    i18n (0.9.5)
+    i18n (1.7.0)
       concurrent-ruby (~> 1.0)
-    jekyll (3.8.5)
+    jekyll (4.0.0)
       addressable (~> 2.4)
       colorator (~> 1.0)
       em-websocket (~> 0.5)
-      i18n (~> 0.7)
-      jekyll-sass-converter (~> 1.0)
+      i18n (>= 0.9.5, < 2)
+      jekyll-sass-converter (~> 2.0)
       jekyll-watch (~> 2.0)
-      kramdown (~> 1.14)
+      kramdown (~> 2.1)
+      kramdown-parser-gfm (~> 1.0)
       liquid (~> 4.0)
       mercenary (~> 0.3.3)
       pathutil (~> 0.9)
-      rouge (>= 1.7, < 4)
+      rouge (~> 3.0)
       safe_yaml (~> 1.0)
-    jekyll-assets (3.0.12)
-      activesupport (~> 5.0)
-      execjs (~> 2.7)
-      extras (~> 0.2)
-      fastimage (~> 2.0, >= 1.8)
-      jekyll (>= 3.5, < 4.0)
-      jekyll-sanity (~> 1.2)
-      liquid-tag-parser (~> 1.0)
-      nokogiri (~> 1.8)
-      pathutil (~> 0.16)
-      sprockets (>= 3.3, < 4.1.beta)
+      terminal-table (~> 1.8)
     jekyll-feed (0.12.1)
       jekyll (>= 3.7, < 5.0)
     jekyll-minifier (0.1.10)
@@ -61,12 +77,10 @@ GEM
       uglifier (~> 4.1)
     jekyll-redirect-from (0.15.0)
       jekyll (>= 3.3, < 5.0)
-    jekyll-sanity (1.2.0)
-      jekyll (~> 3.1)
-    jekyll-sass-converter (1.5.2)
-      sass (~> 3.4)
-    jekyll-seo-tag (2.6.0)
-      jekyll (~> 3.3)
+    jekyll-sass-converter (2.0.1)
+      sassc (> 2.0.1, < 3.0)
+    jekyll-seo-tag (2.6.1)
+      jekyll (>= 3.3, < 5.0)
     jekyll-sitemap (1.3.1)
       jekyll (>= 3.7, < 5.0)
     jekyll-watch (2.2.1)
@@ -74,61 +88,68 @@ GEM
     json (2.2.0)
     json-minify (0.0.3)
       json (> 0)
-    kramdown (1.17.0)
+    kramdown (2.1.0)
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
     liquid (4.0.3)
     liquid-tag-parser (1.9.0)
       extras (~> 0.3)
       liquid (>= 3.0, < 5.0)
-    listen (3.1.5)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
-      ruby_dep (~> 1.2)
+    listen (3.2.0)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.3.6)
     mini_portile2 (2.4.0)
-    minima (2.5.0)
-      jekyll (~> 3.5)
+    minima (2.5.1)
+      jekyll (>= 3.5, < 5.0)
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
-    minitest (5.11.3)
-    nokogiri (1.10.2)
+    minitest (5.12.2)
+    nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    public_suffix (3.0.3)
+    public_suffix (4.0.1)
     rack (2.0.7)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
-    rouge (3.3.0)
-    ruby_dep (1.5.0)
+    rouge (3.12.0)
     safe_yaml (1.0.5)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    sprockets (3.7.2)
+    sassc (2.2.1)
+      ffi (~> 1.9)
+    sprockets (4.0.0)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
+    terminal-table (1.8.0)
+      unicode-display_width (~> 1.1, >= 1.1.1)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
-    uglifier (4.1.20)
+    uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
+    unicode-display_width (1.6.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   autoprefixer-rails
-  jekyll (>= 3)
-  jekyll-assets
+  jekyll (>= 4)
+  jekyll-assets!
   jekyll-feed
   jekyll-minifier
   jekyll-redirect-from
+  jekyll-sanity!
   jekyll-sitemap
   minima (~> 2.0)
+  sass
   tzinfo-data
 
 BUNDLED WITH
-   1.17.2
+   1.17.3


### PR DESCRIPTION
Link to upgrading Jekyll: https://jekyllrb.com/docs/upgrading/3-to-4/#for-plugin-authors
Link to `jekyll-assets` incompatibility: https://github.com/envygeeks/jekyll-assets/pull/620